### PR TITLE
change require to es6 import

### DIFF
--- a/src/provider/Communication/index.js
+++ b/src/provider/Communication/index.js
@@ -1,5 +1,5 @@
 import errors from './errors';
-const jsonrpc = require('jsonrpc-lite');
+import jsonrpc from 'jsonrpc-lite';
 
 class Communication {
     constructor() {


### PR DESCRIPTION
Fix below error when I run the Vite.js example on React.
`TypeError: this.jsonrpc.request is not a function.`

<img width="839" alt="2019-01-29 10 31 05" src="https://user-images.githubusercontent.com/16279779/51962632-aa34a200-2415-11e9-9a77-cde1346746e8.png">
