### PR TITLE
fix: setPublicKey failed with hex key

### DIFF
--- a/src/accountBlock/accountBlock.ts
+++ b/src/accountBlock/accountBlock.ts
@@ -326,11 +326,11 @@ class AccountBlockClass {
             throw err;
         }
 
-        const publicKeyBase64 = isBase64String(publicKey)
+        const publicKeyHex = isHexString(publicKey)
             ? publicKey
-            : Buffer.from(`${ publicKey }`, 'hex').toString('base64');
-        const publicKeyHex = isBase64String(publicKey)
-            ? Buffer.from(`${ publicKey }`, 'base64').toString('hex')
+            : Buffer.from(`${ publicKey }`, 'base64').toString('hex');
+        const publicKeyBase64 = isHexString(publicKey)
+            ? Buffer.from(`${ publicKey }`, 'hex').toString('base64')
             : publicKey;
 
         const address = getAddressFromPublicKey(publicKeyHex);


### PR DESCRIPTION
Cause: some hex strings are also base64 strings. 
Fix: test hex string first instead of base64.