### PR TITLE
Fixed a bug where the websocket cloud not reconnect correctly

### DIFF
--- a/src/IPC/index.js
+++ b/src/IPC/index.js
@@ -43,10 +43,10 @@ class IpcRpc extends IPC_WS {
             this._errored();
         });
         this.socket.on('end', err => {
-            this._connectEnd && this._connectEnd(err);
+            this._doCall(this._connectEnd, err);
         });
         this.socket.on('timeout', err => {
-            this._connectTimeout && this._connectTimeout(err);
+            this._doCall(this._connectTimeout, err);
         });
 
         let ipcBuffer = '';

--- a/src/WS/index.js
+++ b/src/WS/index.js
@@ -5,7 +5,10 @@ class WsRpc extends IPC_WS {
     constructor(path = 'ws://localhost:31420', timeout = 60000, options = {
         protocol: '',
         headers: '',
-        clientConfig: '',
+        clientConfig: {
+            keepalive: true,
+            keepaliveInterval: 30 * 1000
+        },
         retryTimes: 10,
         retryInterval: 10000
     }) {
@@ -72,9 +75,9 @@ class WsRpc extends IPC_WS {
 
     destroy() {
         this.disconnect();
-        this.remove('error');
-        this.remove('close');
-        this.remove('connect');
+        this.removeAll('error');
+        this.removeAll('close');
+        this.removeAll('connect');
         this._destroyed = true;
     }
 }

--- a/src/communication/ipc_ws.js
+++ b/src/communication/ipc_ws.js
@@ -75,13 +75,13 @@ class IpcWs extends Communication {
                 return;
             }
 
-            for (const x of ele) {
-                if (!x.id) {
-                    this.subscribeMethod && this.subscribeMethod(x);
+            for (let i = 0; i < ele.length; i++) {
+                if (!ele[i].id) {
+                    this.subscribeMethod && this.subscribeMethod(ele[i]);
                     continue;
                 }
 
-                const id = x.id;
+                const id = ele[i].id;
                 if (!this.responseCbs[id]) {
                     continue;
                 }
@@ -241,9 +241,9 @@ export default IPC_WS;
 function getIdFromPayloads(payloads) {
     let id;
     if (payloads instanceof Array) {
-        for (const p of payloads) {
-            if (p.id) {
-                id = p.id;
+        for (let i = 0; i < payloads.length; i++) {
+            if (payloads[i].id) {
+                id = payloads[i].id;
                 break;
             }
         }

--- a/src/communication/ipc_ws.js
+++ b/src/communication/ipc_ws.js
@@ -11,27 +11,33 @@ class IpcWs extends Communication {
         this.connectStatus = false;
         this.responseCbs = {};
 
-        this._connectEnd = null;
-        this._connectError = null;
-        this._connectTimeout = null;
-        this._connectConnect = null;
-        this._connectClose = null;
+        this._connectEnd = new Set();
+        this._connectError = new Set();
+        this._connectTimeout = new Set();
+        this._connectConnect = new Set();
+        this._connectClose = new Set();
 
         this.subscribeMethod = null;
     }
 
+    _doCall(s, ...args) {
+        for (const f of s) {
+            f(...args);
+        }
+    }
+
     _connected() {
         this.connectStatus = true;
-        this._connectConnect && this._connectConnect();
+        this._doCall(this._connectConnect);
     }
 
     _closed() {
         this.connectStatus = false;
-        this._connectClose && this._connectClose();
+        this._doCall(this._connectClose);
     }
 
     _errored(err) {
-        this._connectError && this._connectError(err);
+        this._doCall(this._connectError, err);
     }
 
     _parse(data) {
@@ -69,13 +75,13 @@ class IpcWs extends Communication {
                 return;
             }
 
-            for (let i = 0; i < ele.length; i++) {
-                if (!ele[i].id) {
-                    this.subscribeMethod && this.subscribeMethod(ele[i]);
+            for (const x of ele) {
+                if (!x.id) {
+                    this.subscribeMethod && this.subscribeMethod(x);
                     continue;
                 }
 
-                const id = ele[i].id;
+                const id = x.id;
                 if (!this.responseCbs[id]) {
                     continue;
                 }
@@ -164,12 +170,23 @@ class IpcWs extends Communication {
         if (!cb) {
             return this.ERRORS.IPC_ON_CB(type);
         }
-        this[eventType] = cb;
+        this[eventType].add(cb);
     }
 
-    remove(type) {
+    remove(type, cb) {
         const eventType = this._checkOnType(type);
-        eventType && (this[eventType] = null);
+        if (!eventType) {
+            return this.ERRORS.IPC_ON(type);
+        }
+        if (!cb) {
+            return this.ERRORS.IPC_ON_CB(type);
+        }
+        this[eventType].delete(cb);
+    }
+
+    removeAll(type) {
+        const eventType = this._checkOnType(type);
+        eventType && this[eventType].clear();
     }
 
     request(methodName, params) {
@@ -224,9 +241,9 @@ export default IPC_WS;
 function getIdFromPayloads(payloads) {
     let id;
     if (payloads instanceof Array) {
-        for (let i = 0; i < payloads.length; i++) {
-            if (payloads[i].id) {
-                id = payloads[i].id;
+        for (const p of payloads) {
+            if (p.id) {
+                id = p.id;
                 break;
             }
         }

--- a/src/viteAPI/provider.ts
+++ b/src/viteAPI/provider.ts
@@ -21,6 +21,7 @@ class ProviderClass {
         try {
             abort && this._provider.abort(abort);
         } catch (e) {
+            // eslint-disable-line
         }
         this.unsubscribeAll();
 

--- a/src/viteAPI/provider.ts
+++ b/src/viteAPI/provider.ts
@@ -12,14 +12,16 @@ class ProviderClass {
     private requestList: {[id:number]:()=>void} = {};
     private requestId = 0;
 
-
     constructor(provider: any, onInitCallback: Function) {
         this._provider = provider;
         this.connectedOnce(onInitCallback);
     }
 
     setProvider(provider, onInitCallback, abort) {
-        abort && this._provider.abort(abort);
+        try {
+            abort && this._provider.abort(abort);
+        } catch (e) {
+        }
         this.unsubscribeAll();
 
         if (!provider) {
@@ -183,7 +185,7 @@ class ProviderClass {
             return;
         }
 
-        const once = () => {
+        const once = (): void => {
             connectedCB();
             this._provider.remove('connect', once);
         };

--- a/src/viteAPI/provider.ts
+++ b/src/viteAPI/provider.ts
@@ -12,6 +12,7 @@ class ProviderClass {
     private requestList: {[id:number]:()=>void} = {};
     private requestId = 0;
 
+
     constructor(provider: any, onInitCallback: Function) {
         this._provider = provider;
         this.connectedOnce(onInitCallback);
@@ -182,10 +183,12 @@ class ProviderClass {
             return;
         }
 
-        this._provider.on && this._provider.on('connect', () => {
+        const once = () => {
             connectedCB();
-            this._provider.remove('connect');
-        });
+            this._provider.remove('connect', once);
+        };
+
+        this._provider.on && this._provider.on('connect', once);
     }
 }
 


### PR DESCRIPTION
https://github.com/vitelabs/vite.js/blob/5275ec4dbcc4007ef51a520886c13f7bab9f768f/src/communication/ipc_ws.js#L159-L168
Only one callback is supported in class `IpcWs`. It's very easy/careless to be overridden, and then leads to some errors.

In this case, It made the websocket reconnect fail.
https://github.com/vitelabs/vite.js/blob/5275ec4dbcc4007ef51a520886c13f7bab9f768f/src/WS/index.js#L32-L44
https://github.com/vitelabs/vite.js/blob/5275ec4dbcc4007ef51a520886c13f7bab9f768f/src/viteAPI/provider.ts#L185-L188
The second `on('connect', ...)`(provider.ts) overrides the first. 

Solution:
Use `Set` supports multiple callbacks.