### PR TITLE
bugfix for `npm run build` failed in linux

### DIFF
--- a/build/vitejsES5.js
+++ b/build/vitejsES5.js
@@ -34,7 +34,8 @@ function formatFile(filePath, folderLevel) {
     if (!fileStr.match(/(\~@vite\/vitejs\-)/)) {
         return;
     }
-
+    fileStr = fileStr.replace(/(\~@vite\/vitejs-accountblock)/g, "~@vite/vitejs-accountBlock");
+    fileStr = fileStr.replace(/(\~@vite\/vitejs-viteapi)/g, "~@vite/vitejs-viteAPI");
     fileStr = fileStr.replace(/(\~@vite\/vitejs-)/g, folderLevel);
     fs.writeFileSync(filePath, fileStr, 'utf8');
 }


### PR DESCRIPTION
Fix the bug of build failed in linux. (npm run build)
Fix import @vitejs-accountblock error.

<img width="1304" alt="image" src="https://user-images.githubusercontent.com/40378222/164614086-dacdbed2-1186-4dee-ae78-7e8f3b209eb1.png">

<img width="604" alt="image" src="https://user-images.githubusercontent.com/40378222/164613978-0098ac2c-6dbd-485a-ad9f-c6f9b2dfca78.png">

