### PR TITLE
feat: refactor reconnect and support for renew subscription

### DIFF
--- a/src/IPC/index.js
+++ b/src/IPC/index.js
@@ -2,11 +2,7 @@ import IPC_WS from '~@vite/vitejs-communication/ipc_ws';
 const net = require('net');
 
 class IpcRpc extends IPC_WS {
-    constructor(path = '', timeout = 60000, options = {
-        delimiter: '\n',
-        retryTimes: 10,
-        retryInterval: 10000
-    }) {
+    constructor(path = '', timeout = 60000, options = {delimiter: '\n'}) {
         super({
             onEventTypes: [ 'error', 'end', 'timeout', 'data', 'close', 'connect' ],
             sendFuncName: 'write',

--- a/src/viteAPI/connectHandler.js
+++ b/src/viteAPI/connectHandler.js
@@ -1,0 +1,95 @@
+class ConnectHandler {
+    init(provider) {
+        this.provider = provider;
+
+        this.connectedCB = () => {
+            this.provider.isConnected = true;
+            this.provider.requestList && Object.values(this.provider.requestList).forEach(_q => {
+                _q && _q(); // execute the pending requests stored in requestList when connected
+            });
+            this.onInitCallback && this.onInitCallback(this.provider); // execute user-defined callback
+        };
+    }
+
+    onConnect(callback) {
+        if (typeof callback === 'function') {
+            this.onInitCallback = callback;
+        }
+        if (this.provider._provider.type === 'http' || this.provider._provider.connectStatus) {
+            this.connectedCB();
+        } else if (this.provider._provider.on) {
+            this.provider._provider.on('connect', () => { // triggered when the ws/ipc connection is established
+                this.connectedCB();
+                this.provider._provider.remove('connect');
+            });
+            this.setReconnect(); // set reconnect policy
+        }
+    }
+
+    setReconnect() {}
+}
+
+/**
+ * ReconnectHandler supports for auto reconnect when the ws/ipc connection is broken,
+ * it uses `retryTimes` and `retryInterval` for maximum number of retries and the
+ * reconnection interval.
+ */
+export class ReconnectHandler extends ConnectHandler {
+    times = 1;
+
+    constructor(retryTimes = 10, retryInterval = 10000) {
+        super();
+        this.retryTimes = retryTimes;
+        this.retryInterval = retryInterval;
+    }
+
+    setReconnect() {
+        this.provider._provider.on('close', () => {
+            if (this.times > this.retryTimes) {
+                return;
+            }
+            setTimeout(() => {
+                this.times++;
+                this.provider._provider.reconnect();
+            }, this.retryInterval);
+        });
+    }
+}
+
+/**
+ * Always reconnect when the connection is broken, regardless the `retryTimes` defined
+ * in ReconnectCallback
+ */
+export class AlwaysReconnect extends ReconnectHandler {
+    constructor(retryInterval = 10000) {
+        super(1, retryInterval);
+    }
+
+    onConnect(callback) {
+        super.onConnect(callback);
+        this.provider._provider.on && this.provider._provider.on('connect', () => {
+            this.connectedCB();
+            this.times = 0; // reset counter
+        });
+    }
+}
+
+/**
+ * Renew existing subscriptions when the connection is re-established
+ */
+export class RenewSubscription extends ReconnectHandler {
+    onConnect(callback) {
+        super.onConnect(callback);
+        this.provider._provider.on && this.provider._provider.on('connect', () => {
+            this.connectedCB();
+            Object.values(this.provider.subscriptionList).forEach(async p => {
+                if (p.isSubscribe && p.payload) {
+                    const _id = await this.provider._provider.request(p.payload.method, p.payload.params);
+                    p.id = _id.result;
+                }
+            });
+        });
+    }
+}
+
+export default ConnectHandler;

--- a/src/viteAPI/eventEmitter.ts
+++ b/src/viteAPI/eventEmitter.ts
@@ -1,21 +1,23 @@
 import { ProviderType } from './type';
 
 class EventEmitter {
-    readonly id: string;
+    id: string;
     readonly isSubscribe: boolean;
+    readonly payload: {method: string, params: any};
     private provider: ProviderType;
     private timeLoop: any;
     private callback: Function;
 
-    constructor(id: string, provider: ProviderType, isSubscribe: boolean) {
+    constructor(id: string, provider: ProviderType, isSubscribe: boolean, payload: {method: string, params: any}) {
         this.id = id;
         this.callback = null;
         this.provider = provider;
         this.isSubscribe = isSubscribe;
-
+        this.payload = payload;
         this.timeLoop = null;
     }
 
+    // call this method to register the subscription event handler
     on(callback: Function) {
         this.callback = callback;
     }
@@ -25,6 +27,7 @@ class EventEmitter {
         this.provider.unsubscribe(this);
     }
 
+    // called by provider when received subscription event
     emit(result) {
         this.callback && this.callback(result);
     }

--- a/src/viteAPI/index.ts
+++ b/src/viteAPI/index.ts
@@ -7,13 +7,14 @@ import { Default_Contract_TransactionType, encodeContractList, getTransactionTyp
 import { Address, AccountBlockType, Transaction, Hex, Base64, BigInt } from './type';
 
 import Provider from './provider';
+import ConnectHandler from './connectHandler';
 
 
 class ViteAPIClass extends Provider {
     private customTransactionType: Object;
 
-    constructor(provider: any, onInitCallback: Function) {
-        super(provider, onInitCallback);
+    constructor(provider: any, onInitCallback: Function, onConnectCallback?: ConnectHandler) {
+        super(provider, onInitCallback, onConnectCallback);
 
         // { [funcSign + contractAddress]: { contractAddress, abi, transactionType } }
         this.customTransactionType = {};

--- a/src/viteAPI/provider.ts
+++ b/src/viteAPI/provider.ts
@@ -2,19 +2,23 @@ import { requestTimeout } from '~@vite/vitejs-error';
 
 import { RPCRequest, RPCResponse, Methods } from './type';
 import EventEmitter from './eventEmitter';
+import ConnectHandler, { ReconnectHandler } from './connectHandler';
 
 
 class ProviderClass {
     isConnected = false;
-    private _provider: any;
+    private _provider: any; // connection provider
     private subscriptionList: {[id:number]:EventEmitter} = {};
     private subscriptionId = 0;
-    private requestList: {[id:number]:()=>void} = {};
+    private requestList: {[id:number]:()=>void} = {}; // pending request queue
     private requestId = 0;
+    private connectHandler = null;
 
-    constructor(provider: any, onInitCallback: Function) {
+    constructor(provider: any, onInitCallback: Function, onConnectCallback?: ConnectHandler) {
         this._provider = provider;
-        this.connectedOnce(onInitCallback);
+        this.connectHandler = onConnectCallback || new ReconnectHandler();
+        this.connectHandler.init(this);
+        this.connectHandler.onConnect(onInitCallback);
     }
 
     setProvider(provider, onInitCallback, abort) {
@@ -27,7 +31,7 @@ class ProviderClass {
 
         this._provider = provider;
         this.isConnected = false;
-        this.connectedOnce(onInitCallback);
+        this.connectHandler.onConnect(onInitCallback);
     }
 
     unsubscribe(event:EventEmitter) {
@@ -87,24 +91,25 @@ class ProviderClass {
 
         let rep;
         if (this.isConnected) {
-            rep = await this._provider.request(subMethodName, params);
+            rep = await this._provider.request(subMethodName, params); // call rpc
             rep = rep.result;
-        } else {
+        } else { // if the connection is not established, temporarily put the request in the request queue
             rep = await this._onReq('request', subMethodName, ...params);
         }
 
         const subscription = rep;
 
-        if (!Object.keys(this.subscriptionList).length) {
+        if (!Object.keys(this.subscriptionList).length) { // initialize if the subscription list is empty
             this.subscriptionList = {};
+            // register the subscription event handling callback to the connection provider
             this._provider.subscribe && this._provider.subscribe(jsonEvent => {
                 this.subscribeCallback(jsonEvent);
             });
         }
 
-        const event = new EventEmitter(subscription, this, !!this._provider.subscribe);
+        const event = new EventEmitter(subscription, this, !!this._provider.subscribe, {method: subMethodName, params: params});
         if (!this._provider.subscribe) {
-            event.startLoop(jsonEvent => {
+            event.startLoop(jsonEvent => { // polling for http
                 this.subscribeCallback(jsonEvent);
             });
         }
@@ -115,17 +120,17 @@ class ProviderClass {
         return event;
     }
 
-
     private _offReq(_q) {
         delete this.requestList[_q._id];
     }
 
+    // when the connection is not established, the request is stored in requestList and wait to be executed after the connection is established
     private _onReq(type, methods, ...args) {
         return new Promise((res, rej) => {
-            const _q = () => {
+            const _q = () => { // create the request
                 this[type](methods, ...args).then(data => {
                     clearTimeout(_timeout);
-                    this._offReq(_q);
+                    this._offReq(_q); // move the request out of queue after execution
                     res(data);
                 }).catch(err => {
                     this._offReq(_q);
@@ -144,6 +149,7 @@ class ProviderClass {
         });
     }
 
+    // process the event response
     private subscribeCallback(jsonEvent) {
         if (!jsonEvent) {
             return;
@@ -154,6 +160,7 @@ class ProviderClass {
             return;
         }
 
+        // find the matching corresponding event handler in the subscription list
         Object.values(this.subscriptionList).forEach(s => {
             if (s.id !== id) {
                 return;
@@ -164,27 +171,7 @@ class ProviderClass {
                 return;
             }
 
-            s.emit(result);
-        });
-    }
-
-    private connectedOnce(cb) {
-        const connectedCB = () => {
-            this.isConnected = true;
-            this.requestList && Object.values(this.requestList).forEach((_q:()=>void) => {
-                _q && _q();
-            });
-            cb && cb(this);
-        };
-
-        if (this._provider.type === 'http' || this._provider.connectStatus) {
-            connectedCB();
-            return;
-        }
-
-        this._provider.on && this._provider.on('connect', () => {
-            connectedCB();
-            this._provider.remove('connect');
+            s.emit(result); // call the event handling callback defined through event.on
         });
     }
 }


### PR DESCRIPTION
Update:
Refactor reconnect
Add ReconnectHandler, AlwaysReconnect and RenewSubscription connect handlers to support for different use cases.

Usage:
Use auto resubscribe with maximum 5 retries and 1000ms interval.
```
const ws = new WS_RPC(config.wsURL);
const provider = new ViteAPI(ws, () => {
  console.log("Connected");
}, new RenewSubscription(retryTimes = 5, retryInterval = 1000));
```

Use auto resubscribe with maximum retries and default (10000ms) interval.
```
const ws = new WS_RPC(config.wsURL);
const provider = new ViteAPI(ws, () => {
  console.log("Connected");
}, new RenewSubscription(Number.MAX_VALUE));
```

Use auto reconnect with unlimited retries (no resubscribe) and default (10000ms) interval.
```
const ws = new WS_RPC(config.wsURL);
const provider = new ViteAPI(ws, () => {
  console.log("Connected");
}, new AlwaysReconnect());
```

Use default handler (reconnect with 10 retries and 10000ms interval). Compatible with current code. 
```
const ws = new WS_RPC(config.wsURL);
const provider = new ViteAPI(ws, () => {
  console.log("Connected");
});
```
Solved #55 
> Note: Extend ReconnectHandler or base ConnectHandler class if you need to implement your own handler.