### PR TITLE
Feat/package

### DIFF
--- a/src/HTTP/type.ts
+++ b/src/HTTP/type.ts
@@ -80,7 +80,10 @@ export enum TransactionType {
     'DexLockVxForDividend',
     'DexSwitchConfig',
     'DexStakeForPrincipalSVIP',
-    'DexCancelStakeById'
+    'DexCancelStakeById',
+    'DexTransfer',
+    'DexAgentDeposit',
+    'DexAssignedWithdraw'
 }
 
 export declare type TokenInfo = {

--- a/src/IPC/index.js
+++ b/src/IPC/index.js
@@ -2,11 +2,7 @@ import IPC_WS from '~@vite/vitejs-communication/ipc_ws';
 const net = require('net');
 
 class IpcRpc extends IPC_WS {
-    constructor(path = '', timeout = 60000, options = {
-        delimiter: '\n',
-        retryTimes: 10,
-        retryInterval: 10000
-    }) {
+    constructor(path = '', timeout = 60000, options = {delimiter: '\n'}) {
         super({
             onEventTypes: [ 'error', 'end', 'timeout', 'data', 'close', 'connect' ],
             sendFuncName: 'write',

--- a/src/IPC/type.ts
+++ b/src/IPC/type.ts
@@ -80,7 +80,10 @@ export enum TransactionType {
     'DexLockVxForDividend',
     'DexSwitchConfig',
     'DexStakeForPrincipalSVIP',
-    'DexCancelStakeById'
+    'DexCancelStakeById',
+    'DexTransfer',
+    'DexAgentDeposit',
+    'DexAssignedWithdraw'
 }
 
 export declare type TokenInfo = {

--- a/src/WS/type.ts
+++ b/src/WS/type.ts
@@ -80,7 +80,10 @@ export enum TransactionType {
     'DexLockVxForDividend',
     'DexSwitchConfig',
     'DexStakeForPrincipalSVIP',
-    'DexCancelStakeById'
+    'DexCancelStakeById',
+    'DexTransfer',
+    'DexAgentDeposit',
+    'DexAssignedWithdraw'
 }
 
 export declare type TokenInfo = {

--- a/src/abi/type.ts
+++ b/src/abi/type.ts
@@ -80,7 +80,10 @@ export enum TransactionType {
     'DexLockVxForDividend',
     'DexSwitchConfig',
     'DexStakeForPrincipalSVIP',
-    'DexCancelStakeById'
+    'DexCancelStakeById',
+    'DexTransfer',
+    'DexAgentDeposit',
+    'DexAssignedWithdraw'
 }
 
 export declare type TokenInfo = {

--- a/src/accountBlock/account.ts
+++ b/src/accountBlock/account.ts
@@ -837,6 +837,62 @@ class AccountClass {
             params: [id]
         });
     }
+
+    dexTransfer({ destination, tokenId, amount }: {
+        destination: Address;
+        tokenId: TokenId;
+        amount: Uint256;
+    }): AccountBlock {
+        const err = checkParams({ destination, tokenId, amount }, [ 'destination', 'tokenId', 'amount' ]);
+        if (err) {
+            throw err;
+        }
+
+        return this.callContract({
+            abi: Contracts.DexTransfer.abi,
+            toAddress: Contracts.DexTransfer.contractAddress,
+            params: [ destination, tokenId, amount ],
+            tokenId
+        });
+    }
+
+    dexAgentDeposit({ beneficiary, tokenId, amount }: {
+        beneficiary: Address;
+        tokenId: TokenId;
+        amount: BigInt;
+    }): AccountBlock {
+        const err = checkParams({ beneficiary, tokenId, amount }, [ 'beneficiary', 'tokenId', 'amount' ]);
+        if (err) {
+            throw err;
+        }
+
+        return this.callContract({
+            abi: Contracts.DexAgentDeposit.abi,
+            toAddress: Contracts.DexAgentDeposit.contractAddress,
+            params: [beneficiary],
+            tokenId,
+            amount
+        });
+    }
+
+    dexAssignedWithdraw({ destination, tokenId, amount, label = '0x00' }: {
+        destination: Address;
+        tokenId: TokenId;
+        amount: Uint256;
+        label?: Bytes32;
+    }): AccountBlock {
+        const err = checkParams({ destination, tokenId, amount }, [ 'destination', 'tokenId', 'amount' ]);
+        if (err) {
+            throw err;
+        }
+
+        return this.callContract({
+            abi: Contracts.DexAssignedWithdraw.abi,
+            toAddress: Contracts.DexAssignedWithdraw.contractAddress,
+            params: [ destination, tokenId, amount, label ],
+            tokenId
+        });
+    }
 }
 
 export const Account = AccountClass;

--- a/src/accountBlock/type.ts
+++ b/src/accountBlock/type.ts
@@ -80,7 +80,10 @@ export enum TransactionType {
     'DexLockVxForDividend',
     'DexSwitchConfig',
     'DexStakeForPrincipalSVIP',
-    'DexCancelStakeById'
+    'DexCancelStakeById',
+    'DexTransfer',
+    'DexAgentDeposit',
+    'DexAssignedWithdraw'
 }
 
 export declare type TokenInfo = {

--- a/src/communication/type.ts
+++ b/src/communication/type.ts
@@ -80,7 +80,10 @@ export enum TransactionType {
     'DexLockVxForDividend',
     'DexSwitchConfig',
     'DexStakeForPrincipalSVIP',
-    'DexCancelStakeById'
+    'DexCancelStakeById',
+    'DexTransfer',
+    'DexAgentDeposit',
+    'DexAssignedWithdraw'
 }
 
 export declare type TokenInfo = {

--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -278,5 +278,17 @@ export const Contracts = {
     DexCancelStakeById: {
         contractAddress: DexFund_ContractAddress,
         abi: { 'type': 'function', 'name': 'CancelStakeById', 'inputs': [{ 'name': 'id', 'type': 'bytes32' }] }
+    },
+    DexTransfer: {
+        contractAddress: DexFund_ContractAddress,
+        abi: {'type': 'function', 'name': 'Transfer', 'inputs': [ {'name': 'target', 'type': 'address'}, {'name': 'token', 'type': 'tokenId'}, {'name': 'amount', 'type': 'uint256'} ]}
+    },
+    DexAgentDeposit: {
+        contractAddress: DexFund_ContractAddress,
+        abi: {'type': 'function', 'name': 'AgentDeposit', 'inputs': [{'name': 'beneficiary', 'type': 'address'}]}
+    },
+    DexAssignedWithdraw: {
+        contractAddress: DexFund_ContractAddress,
+        abi: {'type': 'function', 'name': 'AssignedWithdraw', 'inputs': [ {'name': 'target', 'type': 'address'}, {'name': 'token', 'type': 'tokenId'}, {'name': 'amount', 'type': 'uint256'}, {'name': 'label', 'type': 'bytes'} ]}
     }
 };

--- a/src/constant/type.ts
+++ b/src/constant/type.ts
@@ -80,7 +80,10 @@ export enum TransactionType {
     'DexLockVxForDividend',
     'DexSwitchConfig',
     'DexStakeForPrincipalSVIP',
-    'DexCancelStakeById'
+    'DexCancelStakeById',
+    'DexTransfer',
+    'DexAgentDeposit',
+    'DexAssignedWithdraw'
 }
 
 export declare type TokenInfo = {

--- a/src/error/type.ts
+++ b/src/error/type.ts
@@ -80,7 +80,10 @@ export enum TransactionType {
     'DexLockVxForDividend',
     'DexSwitchConfig',
     'DexStakeForPrincipalSVIP',
-    'DexCancelStakeById'
+    'DexCancelStakeById',
+    'DexTransfer',
+    'DexAgentDeposit',
+    'DexAssignedWithdraw'
 }
 
 export declare type TokenInfo = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,12 @@ import * as _utils from './utils/index';
 import * as _constant from './constant/index';
 import * as _account from './accountBlock/account';
 import * as _accountBlock from './accountBlock/index';
+import * as _communication from './communication/index';
 import _viteAPI from './viteAPI/index';
 import _wallet from './wallet/index';
-
+import _httpRpc from './HTTP/index';
+import _ipcRpc from './IPC/index';
+import _wsRpc from './WS/index';
 
 // Not Change
 export const abi = _abi;
@@ -17,6 +20,7 @@ export const keystore = _keystore;
 // Add functions
 export const utils = _utils;
 export const constant = _constant;
+export const communication = _communication;
 
 // Change a lot
 export const accountBlock = _accountBlock;
@@ -25,3 +29,6 @@ export const account = _account;
 // Add
 export const ViteAPI = _viteAPI;
 export const wallet = _wallet;
+export const HTTP_RPC = _httpRpc;
+export const IPC_RPC = _ipcRpc;
+export const WS_RPC = _wsRpc;

--- a/src/keystore/type.ts
+++ b/src/keystore/type.ts
@@ -80,7 +80,10 @@ export enum TransactionType {
     'DexLockVxForDividend',
     'DexSwitchConfig',
     'DexStakeForPrincipalSVIP',
-    'DexCancelStakeById'
+    'DexCancelStakeById',
+    'DexTransfer',
+    'DexAgentDeposit',
+    'DexAssignedWithdraw'
 }
 
 export declare type TokenInfo = {

--- a/src/type.ts
+++ b/src/type.ts
@@ -80,7 +80,10 @@ export enum TransactionType {
     'DexLockVxForDividend',
     'DexSwitchConfig',
     'DexStakeForPrincipalSVIP',
-    'DexCancelStakeById'
+    'DexCancelStakeById',
+    'DexTransfer',
+    'DexAgentDeposit',
+    'DexAssignedWithdraw'
 }
 
 export declare type TokenInfo = {

--- a/src/utils/type.ts
+++ b/src/utils/type.ts
@@ -80,7 +80,10 @@ export enum TransactionType {
     'DexLockVxForDividend',
     'DexSwitchConfig',
     'DexStakeForPrincipalSVIP',
-    'DexCancelStakeById'
+    'DexCancelStakeById',
+    'DexTransfer',
+    'DexAgentDeposit',
+    'DexAssignedWithdraw'
 }
 
 export declare type TokenInfo = {

--- a/src/viteAPI/connectHandler.js
+++ b/src/viteAPI/connectHandler.js
@@ -1,0 +1,95 @@
+class ConnectHandler {
+    init(provider) {
+        this.provider = provider;
+
+        this.connectedCB = () => {
+            this.provider.isConnected = true;
+            this.provider.requestList && Object.values(this.provider.requestList).forEach(_q => {
+                _q && _q(); // execute the pending requests stored in requestList when connected
+            });
+            this.onInitCallback && this.onInitCallback(this.provider); // execute user-defined callback
+        };
+    }
+
+    onConnect(callback) {
+        if (typeof callback === 'function') {
+            this.onInitCallback = callback;
+        }
+        if (this.provider._provider.type === 'http' || this.provider._provider.connectStatus) {
+            this.connectedCB();
+        } else if (this.provider._provider.on) {
+            this.provider._provider.on('connect', () => { // triggered when the ws/ipc connection is established
+                this.connectedCB();
+                this.provider._provider.remove('connect');
+            });
+            this.setReconnect(); // set reconnect policy
+        }
+    }
+
+    setReconnect() {}
+}
+
+/**
+ * ReconnectHandler supports for auto reconnect when the ws/ipc connection is broken,
+ * it uses `retryTimes` and `retryInterval` for maximum number of retries and the
+ * reconnection interval.
+ */
+export class ReconnectHandler extends ConnectHandler {
+    times = 1;
+
+    constructor(retryTimes = 10, retryInterval = 10000) {
+        super();
+        this.retryTimes = retryTimes;
+        this.retryInterval = retryInterval;
+    }
+
+    setReconnect() {
+        this.provider._provider.on('close', () => {
+            if (this.times > this.retryTimes) {
+                return;
+            }
+            setTimeout(() => {
+                this.times++;
+                this.provider._provider.reconnect();
+            }, this.retryInterval);
+        });
+    }
+}
+
+/**
+ * Always reconnect when the connection is broken, regardless the `retryTimes` defined
+ * in ReconnectCallback
+ */
+export class AlwaysReconnect extends ReconnectHandler {
+    constructor(retryInterval = 10000) {
+        super(1, retryInterval);
+    }
+
+    onConnect(callback) {
+        super.onConnect(callback);
+        this.provider._provider.on && this.provider._provider.on('connect', () => {
+            this.connectedCB();
+            this.times = 0; // reset counter
+        });
+    }
+}
+
+/**
+ * Renew existing subscriptions when the connection is re-established
+ */
+export class RenewSubscription extends ReconnectHandler {
+    onConnect(callback) {
+        super.onConnect(callback);
+        this.provider._provider.on && this.provider._provider.on('connect', () => {
+            this.connectedCB();
+            Object.values(this.provider.subscriptionList).forEach(async p => {
+                if (p.isSubscribe && p.payload) {
+                    const _id = await this.provider._provider.request(p.payload.method, p.payload.params);
+                    p.id = _id.result;
+                }
+            });
+        });
+    }
+}
+
+export default ConnectHandler;

--- a/src/viteAPI/eventEmitter.ts
+++ b/src/viteAPI/eventEmitter.ts
@@ -1,21 +1,23 @@
 import { ProviderType } from './type';
 
 class EventEmitter {
-    readonly id: string;
+    id: string;
     readonly isSubscribe: boolean;
+    readonly payload: {method: string, params: any};
     private provider: ProviderType;
     private timeLoop: any;
     private callback: Function;
 
-    constructor(id: string, provider: ProviderType, isSubscribe: boolean) {
+    constructor(id: string, provider: ProviderType, isSubscribe: boolean, payload: {method: string, params: any}) {
         this.id = id;
         this.callback = null;
         this.provider = provider;
         this.isSubscribe = isSubscribe;
-
+        this.payload = payload;
         this.timeLoop = null;
     }
 
+    // call this method to register the subscription event handler
     on(callback: Function) {
         this.callback = callback;
     }
@@ -25,6 +27,7 @@ class EventEmitter {
         this.provider.unsubscribe(this);
     }
 
+    // called by provider when received subscription event
     emit(result) {
         this.callback && this.callback(result);
     }

--- a/src/viteAPI/index.ts
+++ b/src/viteAPI/index.ts
@@ -7,13 +7,14 @@ import { Default_Contract_TransactionType, encodeContractList, getTransactionTyp
 import { Address, AccountBlockType, Transaction, Hex, Base64, BigInt } from './type';
 
 import Provider from './provider';
+import ConnectHandler from './connectHandler';
 
 
 class ViteAPIClass extends Provider {
     private customTransactionType: Object;
 
-    constructor(provider: any, onInitCallback: Function) {
-        super(provider, onInitCallback);
+    constructor(provider: any, onInitCallback: Function, onConnectCallback?: ConnectHandler) {
+        super(provider, onInitCallback, onConnectCallback);
 
         // { [funcSign + contractAddress]: { contractAddress, abi, transactionType } }
         this.customTransactionType = {};

--- a/src/viteAPI/provider.ts
+++ b/src/viteAPI/provider.ts
@@ -2,19 +2,23 @@ import { requestTimeout } from '~@vite/vitejs-error';
 
 import { RPCRequest, RPCResponse, Methods } from './type';
 import EventEmitter from './eventEmitter';
+import ConnectHandler, { ReconnectHandler } from './connectHandler';
 
 
 class ProviderClass {
     isConnected = false;
-    private _provider: any;
+    private _provider: any; // connection provider
     private subscriptionList: {[id:number]:EventEmitter} = {};
     private subscriptionId = 0;
-    private requestList: {[id:number]:()=>void} = {};
+    private requestList: {[id:number]:()=>void} = {}; // pending request queue
     private requestId = 0;
+    private connectHandler = null;
 
-    constructor(provider: any, onInitCallback: Function) {
+    constructor(provider: any, onInitCallback: Function, onConnectCallback?: ConnectHandler) {
         this._provider = provider;
-        this.connectedOnce(onInitCallback);
+        this.connectHandler = onConnectCallback || new ReconnectHandler();
+        this.connectHandler.init(this);
+        this.connectHandler.onConnect(onInitCallback);
     }
 
     setProvider(provider, onInitCallback, abort) {
@@ -27,7 +31,7 @@ class ProviderClass {
 
         this._provider = provider;
         this.isConnected = false;
-        this.connectedOnce(onInitCallback);
+        this.connectHandler.onConnect(onInitCallback);
     }
 
     unsubscribe(event:EventEmitter) {
@@ -87,24 +91,25 @@ class ProviderClass {
 
         let rep;
         if (this.isConnected) {
-            rep = await this._provider.request(subMethodName, params);
+            rep = await this._provider.request(subMethodName, params); // call rpc
             rep = rep.result;
-        } else {
+        } else { // if the connection is not established, temporarily put the request in the request queue
             rep = await this._onReq('request', subMethodName, ...params);
         }
 
         const subscription = rep;
 
-        if (!Object.keys(this.subscriptionList).length) {
+        if (!Object.keys(this.subscriptionList).length) { // initialize if the subscription list is empty
             this.subscriptionList = {};
+            // register the subscription event handling callback to the connection provider
             this._provider.subscribe && this._provider.subscribe(jsonEvent => {
                 this.subscribeCallback(jsonEvent);
             });
         }
 
-        const event = new EventEmitter(subscription, this, !!this._provider.subscribe);
+        const event = new EventEmitter(subscription, this, !!this._provider.subscribe, {method: subMethodName, params: params});
         if (!this._provider.subscribe) {
-            event.startLoop(jsonEvent => {
+            event.startLoop(jsonEvent => { // polling for http
                 this.subscribeCallback(jsonEvent);
             });
         }
@@ -115,17 +120,17 @@ class ProviderClass {
         return event;
     }
 
-
     private _offReq(_q) {
         delete this.requestList[_q._id];
     }
 
+    // when the connection is not established, the request is stored in requestList and wait to be executed after the connection is established
     private _onReq(type, methods, ...args) {
         return new Promise((res, rej) => {
-            const _q = () => {
+            const _q = () => { // create the request
                 this[type](methods, ...args).then(data => {
                     clearTimeout(_timeout);
-                    this._offReq(_q);
+                    this._offReq(_q); // move the request out of queue after execution
                     res(data);
                 }).catch(err => {
                     this._offReq(_q);
@@ -144,6 +149,7 @@ class ProviderClass {
         });
     }
 
+    // process the event response
     private subscribeCallback(jsonEvent) {
         if (!jsonEvent) {
             return;
@@ -154,6 +160,7 @@ class ProviderClass {
             return;
         }
 
+        // find the matching corresponding event handler in the subscription list
         Object.values(this.subscriptionList).forEach(s => {
             if (s.id !== id) {
                 return;
@@ -164,27 +171,7 @@ class ProviderClass {
                 return;
             }
 
-            s.emit(result);
-        });
-    }
-
-    private connectedOnce(cb) {
-        const connectedCB = () => {
-            this.isConnected = true;
-            this.requestList && Object.values(this.requestList).forEach((_q:()=>void) => {
-                _q && _q();
-            });
-            cb && cb(this);
-        };
-
-        if (this._provider.type === 'http' || this._provider.connectStatus) {
-            connectedCB();
-            return;
-        }
-
-        this._provider.on && this._provider.on('connect', () => {
-            connectedCB();
-            this._provider.remove('connect');
+            s.emit(result); // call the event handling callback defined through event.on
         });
     }
 }

--- a/src/viteAPI/type.ts
+++ b/src/viteAPI/type.ts
@@ -80,7 +80,10 @@ export enum TransactionType {
     'DexLockVxForDividend',
     'DexSwitchConfig',
     'DexStakeForPrincipalSVIP',
-    'DexCancelStakeById'
+    'DexCancelStakeById',
+    'DexTransfer',
+    'DexAgentDeposit',
+    'DexAssignedWithdraw'
 }
 
 export declare type TokenInfo = {

--- a/src/vitejs/index.ts
+++ b/src/vitejs/index.ts
@@ -6,10 +6,14 @@ import * as _error from '~@vite/vitejs-error';
 import * as _keystore from '~@vite/vitejs-keystore';
 import * as _utils from '~@vite/vitejs-utils';
 import * as _constant from '~@vite/vitejs-constant';
+import * as _account from '~@vite/vitejs-accountblock/account';
 import * as _accountBlock from '~@vite/vitejs-accountblock';
-import _viteapi from '~@vite/vitejs-viteapi';
+import * as _communication from '~@vite/vitejs-communication';
+import _viteAPI from '~@vite/vitejs-viteapi';
 import _wallet from '~@vite/vitejs-wallet';
-
+import _httpRpc from '~@vite/vitejs-http';
+import _ipcRpc from '~@vite/vitejs-ipc';
+import _wsRpc from '~@vite/vitejs-ws';
 
 // Not Change
 export const abi = _abi;
@@ -19,10 +23,16 @@ export const keystore = _keystore;
 // Add functions
 export const utils = _utils;
 export const constant = _constant;
+export const communication = _communication;
 
 // Change a lot
 export const accountBlock = _accountBlock;
+export const account = _account;
 
 // Add
-export const ViteAPI = _viteapi;
+export const ViteAPI = _viteAPI;
 export const wallet = _wallet;
+export const HTTP_RPC = _httpRpc;
+export const IPC_RPC = _ipcRpc;
+export const WS_RPC = _wsRpc;
+

--- a/src/vitejs/type.ts
+++ b/src/vitejs/type.ts
@@ -80,7 +80,10 @@ export enum TransactionType {
     'DexLockVxForDividend',
     'DexSwitchConfig',
     'DexStakeForPrincipalSVIP',
-    'DexCancelStakeById'
+    'DexCancelStakeById',
+    'DexTransfer',
+    'DexAgentDeposit',
+    'DexAssignedWithdraw'
 }
 
 export declare type TokenInfo = {

--- a/src/wallet/type.ts
+++ b/src/wallet/type.ts
@@ -80,7 +80,10 @@ export enum TransactionType {
     'DexLockVxForDividend',
     'DexSwitchConfig',
     'DexStakeForPrincipalSVIP',
-    'DexCancelStakeById'
+    'DexCancelStakeById',
+    'DexTransfer',
+    'DexAgentDeposit',
+    'DexAssignedWithdraw'
 }
 
 export declare type TokenInfo = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
             "~@vite/vitejs-abi": ["abi/index.ts"],
             "~@vite/vitejs-accountblock": ["accountBlock/index.ts"],
             "~@vite/vitejs-accountblock/*": ["accountBlock/*"],
+            "~@vite/vitejs-communication": ["communication/index.js"],
             "~@vite/vitejs-communication/*": ["communication/*"],
             "~@vite/vitejs-constant": ["constant/index.ts"],
             "~@vite/vitejs-error": ["error/index.ts"],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,9 +30,9 @@ module.exports = {
         wallet: path.join(baseDir, '/wallet/index.ts'),
         utils: path.join(baseDir, '/utils/index.ts'),
         vitejs: path.join(baseDir, '/vitejs/index.ts'),
-        WS: path.join(baseDir, 'WS/index.js'),
-        HTTP: path.join(baseDir, 'HTTP/index.js'),
-        IPC: path.join(baseDir, 'IPC/index.js')
+        WS: path.join(baseDir, '/WS/index.js'),
+        HTTP: path.join(baseDir, '/HTTP/index.js'),
+        IPC: path.join(baseDir, '/IPC/index.js')
     },
     output: {
         globalObject: 'this',
@@ -81,6 +81,9 @@ module.exports = {
             '~@vite/vitejs-viteapi': path.join(__dirname, '/src/viteAPI/'),
             '~@vite/vitejs-wallet': path.join(__dirname, '/src/wallet/'),
             '~@vite/vitejs-accountblock': path.join(__dirname, '/src/accountBlock/'),
+            '~@vite/vitejs-ipc': path.join(__dirname, '/src/IPC/'),
+            '~@vite/vitejs-http': path.join(__dirname, '/src/HTTP/'),
+            '~@vite/vitejs-ws': path.join(__dirname, '/src/WS/'),
             '~@vite/vitejs': path.join(__dirname, '/src/vitejs/')
         },
         fallback: {


### PR DESCRIPTION
Add HTTP, WS, and IPC modules into the main @vite/vitejs package so they can be imported from there. 

Currently there are multiple modules in vitejs published on npm. The reason of doing so was because we wanted give developer the choice to choose the specific packages to install to save space and loading time. However, this proved not working out very well. On one hand, people are used to import everything from one package. On the other hand, the current @vite/vitejs package still contains all the others except the RPC communication modules, which doesn’t make sense since it cannot be used alone in the meantime with a relatively big package size. So we decide to consolidate.

In 2.3.19, @vite/vitejs-communication, @vite/vitejs-http, @vite/vitejs-ipc, and @vite/vitejs-ws will be added into @vite/vitejs while all the other packages are kept unchanged for backwards compatibility. ***The developers should change their code from using the above packages to @vite/vitejs as early as possible***.

Starting from 2.4.0, the following packages will no longer published. The related classes/functions should be imported from @vite/vitejs

- @vite/vitejs-abi
- @vite/vitejs-accountblock
- @vite/vitejs-communication
- @vite/vitejs-constant
- @vite/vitejs-error
- @vite/vitejs-http
- @vite/vitejs-ipc
- @vite/vitejs-ws
- @vite/vitejs-wallet
- @vite/vitejs-utils
- @vite/vitejs-viteapi

Also will remove the legacy keystore module from @vite/vitejs to reduce package size. Old keystore users who still need this function should import from @vite/vitejs-keystore in 2.4.0.

Packages that will be remained in 2.4.0

- @vite/vitejs
- @vite/vitejs-keystore